### PR TITLE
Fixes on minitel speed setup

### DIFF
--- a/arduino/Minitel1B_Telnet_Pro/Minitel1B_Telnet_Pro.ino
+++ b/arduino/Minitel1B_Telnet_Pro/Minitel1B_Telnet_Pro.ino
@@ -100,11 +100,11 @@ void setup() {
 
   // Minitel setup
   speed = MINITEL_BAUD_TRY;
-  MINITEL_PORT.begin(speed); // change minitel1b_Hard default uart speed
+  MINITEL_PORT.updateBaudRate(speed); // override minitel1b_Hard default speed
   if (speed != minitel.currentSpeed()) { // avoid unwanted characters when restarting
-    if ( (speed = minitel.searchSpeed()) < MINITEL_BAUD_TRY) {   // search speed
-      if (minitel.changeSpeed(MINITEL_BAUD_TRY) < 0) {           // set to MINITEL_BAUD_TRY if different
-        speed = minitel.searchSpeed();                           // search speed again if change has failed
+    if ( (speed = minitel.searchSpeed()) < MINITEL_BAUD_TRY) {    // search speed
+      if ( (speed = minitel.changeSpeed(MINITEL_BAUD_TRY)) < 0) { // set to MINITEL_BAUD_TRY if different
+        speed = minitel.searchSpeed();                         // search speed again if change has failed
       }
     }
   }


### PR DESCRIPTION
1- Using .updateBaudRate instead of .begin enables minitel.currentSpeed to return speed properly. So searchSpeed is avoided after soft restart.

2- add speed assignement when calling changeSpeed. Wrong speed was displayed at first boot.